### PR TITLE
Include NamedTypeWithAltsNode instances in definitions

### DIFF
--- a/internal/testutils/golden_file_matcher.go
+++ b/internal/testutils/golden_file_matcher.go
@@ -35,7 +35,7 @@ func (g *goldenFileMatcher) Match(actual interface{}) (success bool, err error) 
 	expectedFile := actualFile + g.extension
 
 	// Run diff to check for differences
-	cmd := exec.Command("diff", "-u", g.actualFile, expectedFile)
+	cmd := exec.Command("diff", "-u", expectedFile, g.actualFile)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Non-zero exit code from diff indicates differences

--- a/internal/typeregistry/graph.go
+++ b/internal/typeregistry/graph.go
@@ -16,6 +16,7 @@ type Node interface {
 	DSTNode() dst.Node
 	Pkg() *decorator.Package
 	ID() TypeID
+	// Inbound is the count of edges into this node
 	Inbound() int
 }
 


### PR DESCRIPTION
The SchemaBuilder render logic was passing over
typeregistry.NamedTypeWithAltsNode in the logic that selects nodes for inclusion in the schema's definitions.  Including it Fixes #2.

Along the way, added logic to avoid writing empty "**properties**" definitions in cases where struct properties have no documentation to include there.