### PR TITLE
ci: make clean-checkout check reliable

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,13 @@ name: Go
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+
+concurrency:
+  group: go-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/internal/builder/basic_test.go
+++ b/internal/builder/basic_test.go
@@ -41,7 +41,9 @@ func TestBasic(t *testing.T) {
 		// Ensure the temp module's dependencies are tidy before generation.
 		preExit, preStdout, preStderr, err := testutils.RunCommand("go", tempDir, "mod", "tidy")
 		require.NoError(t, err)
-		CmdSuccessAssertions(t, preStdout, preStderr, preExit)
+		// A clean module cache makes Go report dependency downloads on stderr.
+		// That is normal progress output; the command's exit status determines success.
+		require.Equal(t, 0, preExit, "stdout:\n%s\nstderr:\n%s", preStdout, preStderr)
 
 		exitCode, stdout, stderr, err := testutils.RunCommand("go", tempDir, "generate", "./...")
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- allow normal Go dependency download progress during clean-checkout tests
- run PR CI once per update while retaining post-merge verification on `main`
- cancel superseded workflow runs for the same PR or ref

## Proof
- clean-cache `TestBasic/test6-providers` reproduction passes
- exact test/generate/no-change/test workflow passes from a clean commit
- pre-commit golangci check passes