### PR TITLE
chore: remove committed binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/.DS_Store
+bin/
 # Do not use legacy v1 docs; canonical spec is under docs/spec/
 docs/v1-*.md
 website/package-lock.json


### PR DESCRIPTION
## Summary
- remove the tracked `bin/gen-jsonschema` executable
- ignore the entire `bin/` directory

## Verification
- `go test ./...`