### PR TITLE
docs: document v0.11 schema features

### DIFF
--- a/ephemeral/worklog/202607112007-docs-v0.11.md
+++ b/ephemeral/worklog/202607112007-docs-v0.11.md
@@ -1,0 +1,29 @@
+# Session worklog: v0.11 documentation surfaces
+
+- Goal: ensure the v0.11 nullable enum/AsRef and stable interface wire-value behavior is documented in the three user-specified surfaces: the agent skill, root `llms.txt`, and website content.
+- Worktree: `/Users/tyler/src/.worktrees/go-gen-jsonschema/docs-v0.11`
+- Branch: `codex/docs-v0.11`, based on live `origin/main` at `0d5996c`.
+- Root checkout intentionally left unchanged.
+- Baseline proof: `go test ./...` passed before the worktree was created.
+- skill_use: session-worklog source=pagerguild/core-tools -> record source gaps, generation, proof, and delivery state.
+- skill_use: repo-proof-policy source=pagerguild/core-tools -> select docs, skill-generation, website-build, and link-check gates.
+
+## Activity
+
+- `git fetch origin --prune --tags` -> confirmed merged v0.11 implementation at `0d5996c`.
+- doc_bug: `llms.txt` still described Nullable as scalar/struct-only and only showed the split interface registration API after v0.11 shipped.
+- decision: update exactly the three requested surfaces: skill entry/reference generation, root `llms.txt`, and website feature content.
+- skill: expanded `SKILL.md` with cohesive interface DSL guidance and regenerated the source-backed `references/examples.md` from the compiling nullable enum/AsRef example.
+- llms: documented nullable enum/AsRef shapes, stable `Impl` wire values, backwards-compatible split registration, nullable `$ref` behavior, and new API table entries.
+- website: added concrete nullable enum/AsRef guidance to Optionality and nullable `$ref` schema shape to Shared Definitions; existing Interfaces page already contained the cohesive DSL and compatibility explanation.
+
+## Proof
+
+- `go run ./internal/cmd/doc-gen --check` -> pass.
+- `go generate ./...` twice -> pass; diff hash unchanged (`f281c527...`).
+- `go build ./...` -> pass.
+- `go test ./...` -> pass.
+- `git diff --check` -> pass.
+- `cd website && npm ci && npm run check` -> pass; 13 pages built and all links across 17 HTML pages resolved.
+- rendered_route_check: built Optionality and Shared Definitions pages contain the new headings; built Interfaces page contains `Discriminator`/`Impl`; built `llms.txt` is copied into the website artifact.
+- branch_state: `codex/docs-v0.11` ready for commit and PR from live `origin/main`; root checkout remains unchanged.

--- a/internal/cmd/doc-gen/skill-examples.json
+++ b/internal/cmd/doc-gen/skill-examples.json
@@ -62,16 +62,16 @@
     },
     {
       "id": "ref-types",
-      "title": "Shared $defs via AsRef",
-      "when": "Use AsRef() on a type's own registration when it's referenced from multiple places and should be rendered once as a \"$ref\" into \"$defs\" instead of being inlined at every reference site.",
+      "title": "Shared $defs and nullable references",
+      "when": "Use AsRef() on a type's own registration when it should be rendered once into $defs. Nullable can wrap that referenced struct or a registered enum while keeping the containing property required.",
       "sections": [
         {
           "source": "examples/ref_types/types.go",
-          "declarations": ["Shared", "Container"]
+          "declarations": ["Shared", "Container", "Mode", "ModeFast", "ModeSafe", "NullableConfig"]
         },
         {
           "source": "examples/ref_types/schema.go",
-          "registrations": ["Shared.Schema", "Container.Schema"]
+          "registrations": ["Shared.Schema", "Container.Schema", "NullableConfig.Schema"]
         }
       ]
     }

--- a/llms.txt
+++ b/llms.txt
@@ -138,7 +138,8 @@ Supported wrapper shapes:
 
 - `Optional`: scalars and named scalars, structs, pointers, arrays and slices,
   supported explicit references, and registered interface fields.
-- `Nullable`: scalars, structs, and pointers to structs.
+- `Nullable`: scalars, registered enums, structs, pointers to structs, and
+  structs registered with `AsRef()`.
 
 Wrappers must be the complete type of a direct named struct field. Aliases,
 defined wrapper types, embedding, nesting, wrappers inside containers, and
@@ -254,21 +255,35 @@ type Batch struct {
 }
 ```
 
-Register the field, implementations, and optional custom discriminator:
+Preferred registration keeps every implementation beside its stable wire
+discriminator:
 
 ```go
 var _ = jsonschema.NewJSONSchemaMethod(
     Batch.Schema,
-    jsonschema.WithInterface(Batch{}.Events),
-    jsonschema.WithInterfaceImpls(Batch{}.Events, Created{}, (*Deleted)(nil)),
-    jsonschema.WithDiscriminator(Batch{}.Events, "!kind"),
+    jsonschema.WithInterface(
+        Batch{}.Events,
+        jsonschema.Discriminator("!kind"),
+        jsonschema.Impl("created", Created{}),
+        jsonschema.Impl("deleted", (*Deleted)(nil)),
+    ),
 )
 ```
 
-The default discriminator property is `!type`. The schema requires the chosen
-discriminator on every union value. Generated decoding preserves value versus
-pointer implementations, reports a failing slice index, and assigns the
-destination only after the entire value decodes successfully.
+`Impl`'s first argument is the exact discriminator used by both the schema
+`const` and generated unmarshal dispatch. The default discriminator property is
+`!type`. Generated decoding preserves value versus pointer implementations,
+reports a failing slice index, and assigns the destination only after the
+entire value decodes successfully.
+
+The split form remains supported for compatibility. Without explicit `Impl`
+values, discriminators continue to derive from Go type names:
+
+```go
+jsonschema.WithInterface(Batch{}.Events),
+jsonschema.WithInterfaceImpls(Batch{}.Events, Created{}, (*Deleted)(nil)),
+jsonschema.WithDiscriminator(Batch{}.Events, "!kind"),
+```
 
 The generator writes an unmarshaler, not a discriminator-aware marshaler. If a
 decoded interface value must marshal back into schema-valid JSON, each concrete
@@ -280,7 +295,7 @@ func (c Created) MarshalJSON() ([]byte, error) {
     return json.Marshal(struct {
         Kind string `json:"!kind"`
         plain
-    }{Kind: "Created", plain: plain(c)})
+    }{Kind: "created", plain: plain(c)})
 }
 ```
 
@@ -315,6 +330,29 @@ type Container struct {
 
 var _ = jsonschema.NewJSONSchemaMethod(Shared.Schema, jsonschema.AsRef())
 var _ = jsonschema.NewJSONSchemaMethod(Container.Schema)
+```
+
+`Nullable` can wrap an `AsRef()` struct or registered enum. Both properties
+remain required; their schemas become `anyOf` unions with JSON null, and the
+referenced struct remains in `$defs`:
+
+```go
+type Mode string
+
+const (
+    ModeFast Mode = "fast"
+    ModeSafe Mode = "safe"
+)
+
+type NullableConfig struct {
+    Mode   jsonschema.Nullable[Mode]   `json:"mode"`
+    Shared jsonschema.Nullable[Shared] `json:"shared"`
+}
+
+var (
+    _ = jsonschema.NewJSONSchemaMethod(NullableConfig.Schema)
+    _ = jsonschema.NewEnumType[Mode]()
+)
 ```
 
 `$defs` are assembled per generated JSON file, keyed by the type's bare name.
@@ -358,7 +396,9 @@ must be preserved.
 | `NewInterfaceImpl[I](impls...)` | Legacy package-level interface registration. |
 | `WithEnum(field)` | Render same-package typed string or numeric constant values. |
 | `WithStringerEnum(field)` | Render integer constant names as strings. |
-| `WithInterface(field)` | Mark an interface or direct interface-slice field. |
+| `WithInterface(field, options...)` | Register an interface field, optionally with cohesive `Discriminator` and `Impl` options. |
+| `Discriminator(name)` | Set the discriminator property inside `WithInterface`. |
+| `Impl(value, implementation)` | Bind a stable wire discriminator to an implementation inside `WithInterface`. |
 | `WithInterfaceImpls(field, impls...)` | List its accepted concrete types. |
 | `WithDiscriminator(field, name)` | Override the default `!type` property. |
 | `WithFunction(field, fn)` | Render a field schema with a package function. |

--- a/skills/go-gen-jsonschema/SKILL.md
+++ b/skills/go-gen-jsonschema/SKILL.md
@@ -172,6 +172,10 @@ custom discriminators, free-function registration, shared `$ref`/`$defs` via
 `AsRef()`, and the full CLI/flag reference live in
 [references/registration-api.md](references/registration-api.md). Read it
 when a type uses enums, interfaces, or you need non-default generation flags.
+For stable interface wire values, prefer the cohesive
+`WithInterface(field, Discriminator(name), Impl(value, implementation), ...)`
+form. The split `WithInterface`/`WithInterfaceImpls`/`WithDiscriminator` form
+remains supported and derives discriminator values from Go type names.
 By default, a struct type referenced from multiple places is inlined at every
 call site; add `AsRef()` to its registration to render it once as a `"$ref"`
 into `"$defs"` instead.

--- a/skills/go-gen-jsonschema/references/examples.md
+++ b/skills/go-gen-jsonschema/references/examples.md
@@ -196,9 +196,9 @@ var _ = jsonschema.NewJSONSchemaMethod(
 )
 ```
 
-## Shared $defs via AsRef
+## Shared $defs and nullable references
 
-Use AsRef() on a type's own registration when it's referenced from multiple places and should be rendered once as a "$ref" into "$defs" instead of being inlined at every reference site.
+Use AsRef() on a type's own registration when it should be rendered once into $defs. Nullable can wrap that referenced struct or a registered enum while keeping the containing property required.
 
 Source: [`examples/ref_types/types.go`](../../../examples/ref_types/types.go)
 
@@ -216,6 +216,21 @@ type Container struct {
 	Primary Shared   `json:"primary"`
 	Others  []Shared `json:"others"`
 }
+
+// Mode is a registered string enum used to prove nullable enum rendering.
+type Mode string
+
+const (
+	ModeFast Mode = "fast"
+	ModeSafe Mode = "safe"
+)
+
+// NullableConfig exercises the two nullable shapes that retain reusable
+// contracts without widening Nullable support to arbitrary schema nodes.
+type NullableConfig struct {
+	Mode   jsonschema.Nullable[Mode]   `json:"mode"`
+	Shared jsonschema.Nullable[Shared] `json:"shared"`
+}
 ```
 
 Source: [`examples/ref_types/schema.go`](../../../examples/ref_types/schema.go)
@@ -226,4 +241,9 @@ Source: [`examples/ref_types/schema.go`](../../../examples/ref_types/schema.go)
 var _ = jsonschema.NewJSONSchemaMethod(Shared.Schema, jsonschema.AsRef())
 
 var _ = jsonschema.NewJSONSchemaMethod(Container.Schema)
+
+var (
+	_ = jsonschema.NewJSONSchemaMethod(NullableConfig.Schema)
+	_ = jsonschema.NewEnumType[Mode]()
+)
 ```

--- a/website/src/content/docs/features/optionality.md
+++ b/website/src/content/docs/features/optionality.md
@@ -55,6 +55,34 @@ Strict schemas require every property to appear in `required`. Use
 `Nullable[T]` for the required-plus-null pattern. Do not use `Optional[T]` in a
 strict schema because it deliberately removes the property from `required`.
 
+## Nullable enums and shared reference types
+
+`Nullable` can wrap a registered enum or a struct registered with `AsRef()`:
+
+```go
+type Mode string
+
+const (
+    ModeFast Mode = "fast"
+    ModeSafe Mode = "safe"
+)
+
+type Config struct {
+    Mode   jsonschema.Nullable[Mode]   `json:"mode"`
+    Shared jsonschema.Nullable[Shared] `json:"shared"`
+}
+
+var (
+    _ = jsonschema.NewJSONSchemaMethod(Shared.Schema, jsonschema.AsRef())
+    _ = jsonschema.NewJSONSchemaMethod(Config.Schema)
+    _ = jsonschema.NewEnumType[Mode]()
+)
+```
+
+Both properties remain in `required`. The enum renders as `anyOf` containing
+its enum schema and null. The shared struct renders as `anyOf` containing its
+`$ref` and null, while the referenced object remains available in `$defs`.
+
 ## Supported shapes
 
 `Optional` supports scalars and named scalars, structs, pointers, arrays and
@@ -65,4 +93,6 @@ Aliases, defined wrappers, embedding, nesting, wrappers inside containers, and
 unsupported Nullable shapes are rejected during generation.
 
 See the compiling [`examples/optionality`](https://github.com/tylergannon/go-gen-jsonschema/tree/main/examples/optionality)
-package for generated output and negative cases.
+package for general wrapper coverage and
+[`examples/ref_types`](https://github.com/tylergannon/go-gen-jsonschema/tree/main/examples/ref_types)
+for nullable enum and `AsRef` validation coverage.

--- a/website/src/content/docs/features/ref-types.md
+++ b/website/src/content/docs/features/ref-types.md
@@ -26,6 +26,34 @@ var _ = jsonschema.NewJSONSchemaMethod(Container.Schema)
 and both `primary` and `others.items` reference it via `$ref` instead of
 repeating its properties.
 
+## Nullable references
+
+An `AsRef()` struct can be the value inside `Nullable[T]`:
+
+```go
+type NullableConfig struct {
+    Shared jsonschema.Nullable[Shared] `json:"shared"`
+}
+
+var _ = jsonschema.NewJSONSchemaMethod(Shared.Schema, jsonschema.AsRef())
+var _ = jsonschema.NewJSONSchemaMethod(NullableConfig.Schema)
+```
+
+The property remains required and accepts either the shared definition or JSON
+null. Its generated shape is equivalent to:
+
+```json
+{
+  "anyOf": [
+    { "$ref": "#/$defs/Shared" },
+    { "type": "null" }
+  ]
+}
+```
+
+The generator keeps the reachable `Shared` definition in the containing
+schema's `$defs`; nullable wrapping does not inline or drop it.
+
 Notes:
 
 - `AsRef()` only changes how `Shared` is rendered at *other* types' reference


### PR DESCRIPTION
## Summary
- expand the agent skill with source-backed nullable enum/AsRef examples and cohesive interface DSL guidance
- update llms.txt for the v0.11 nullable shapes, stable wire values, compatibility form, and registration API
- add concrete nullable enum and nullable reference guidance to the website

## Proof
- go run ./internal/cmd/doc-gen --check
- go generate ./... twice (idempotent)
- go build ./...
- go test ./...
- git diff --check
- cd website && npm run check
- rendered route/content checks across skill, llms.txt, and website output